### PR TITLE
remove excess/deprecated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,6 @@ script!
   * install latest long term support version of node
 * npm packages:
   * yarn
-  * create-react-app
-  * prettier
-  * javascript-typescript-langserver
-  * babel
-  * eslint
 
 ### macOS settings configuration
 

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -31,5 +31,6 @@ else
   rvm install 3.0.0
 fi
 
-fancy_echo "Installing common npm packages"
-npm install -g yarn create-react-app prettier javascript-typescript-langserver babel eslint
+
+fancy_echo "Installing yarn"
+npm install -g yarn


### PR DESCRIPTION
The npm install included was a bit of a red flag for me, but let me know if I missed something in dropping most of these.

Slightly long-winded(sorry) reasoning for these changes:

For `prettier` and `eslint`, it's commonly recommended to avoid installing either of these globally, since it can cause compatibility issues. For `eslint` in particular, `react-scripts` [will check for incompatible versions and fail to start](https://github.com/facebook/create-react-app/blob/main/packages/react-scripts/scripts/utils/verifyPackageTree.js#L31), and if we have mis-matched global installs of `prettier`, we could end up kicking changes back and forth (say we're using default settings, function parentheses on single argument arrow functions was just recently made default).

`javascript-typescript-langserver` and `babel` are both deprecated, the latter in favor of `babel-cli` which has since been deprecated in favor of `@babel/cli`. This alongside `@babel/core` should also be project specific (see [here](https://babeljs.io/docs/en/babel-cli#install))

Finally, there's no need to install `create-react-app` directly since it can be invoked with `npx create-react-app my-app`, as long as you are running npm >= 5.2.0, which this script should be installing.