### PR TITLE
Compatibility updates

### DIFF
--- a/setup_script.sh
+++ b/setup_script.sh
@@ -67,63 +67,68 @@ elif ! [[ -z "$BREW_DIR" ]] && [[ $(which brew) == $BREW_DIR/brew ]]; then
   brew update
   brew -v
 else
+  unset BREW_DIR
   fancy_echo "No action taken for Homebrew; path did not match CPU architecture"
 fi
 
-if [ ! -d /Applications/"Google Chrome.app" ]; then
-  fancy_echo "Google Chrome not found.. installing Google Chrome"
-  brew install --cask google-chrome
+if [[ -z "$BREW_DIR" ]]; then
+  fancy_echo "Skipping all Homebrew managed applications..."
 else
-  fancy_echo "Google Chrome detected"
-  fancy_echo "Skipping Google Chrome..."
-fi
+  if [ ! -d /Applications/"Google Chrome.app" ]; then
+    fancy_echo "Google Chrome not found.. installing Google Chrome"
+    brew install --cask google-chrome
+  else
+    fancy_echo "Google Chrome detected"
+    fancy_echo "Skipping Google Chrome..."
+  fi
 
-if [ ! -d /Applications/Slack.app ]; then
-  fancy_echo "Slack not found.. installing Slack"
-  brew install --cask slack
-else
-  fancy_echo "Slack detected"
-  fancy_echo "Skipping Slack..."
-fi
+  if [ ! -d /Applications/Slack.app ]; then
+    fancy_echo "Slack not found.. installing Slack"
+    brew install --cask slack
+  else
+    fancy_echo "Slack detected"
+    fancy_echo "Skipping Slack..."
+  fi
 
-if [ ! -d /Applications/Rectangle.app ]; then
-  fancy_echo "Rectangle not found.. installing Rectangle"
-  brew install --cask rectangle
-else
-  fancy_echo "Rectangle detected"
-  fancy_echo "Skipping Rectangle..."
-fi
+  if [ ! -d /Applications/Rectangle.app ]; then
+    fancy_echo "Rectangle not found.. installing Rectangle"
+    brew install --cask rectangle
+  else
+    fancy_echo "Rectangle detected"
+    fancy_echo "Skipping Rectangle..."
+  fi
 
-if [ ! -d /Applications/'1Password 7.app' ]; then
-  fancy_echo "1password not found.. installing 1password"
-  brew install --cask 1password
-else
-  fancy_echo "1password detected"
-  fancy_echo "Skipping 1password..."
-fi
+  if [ ! -d /Applications/'1Password 7.app' ]; then
+    fancy_echo "1password not found.. installing 1password"
+    brew install --cask 1password
+  else
+    fancy_echo "1password detected"
+    fancy_echo "Skipping 1password..."
+  fi
 
-if [ ! -d /Applications/'Spotify.app' ]; then
-  fancy_echo "Spotify not found.. installing Spotify"
-  brew install --cask spotify
-else
-  fancy_echo "Spotify detected"
-  fancy_echo "Skipping Spotify..."
-fi
+  if [ ! -d /Applications/'Spotify.app' ]; then
+    fancy_echo "Spotify not found.. installing Spotify"
+    brew install --cask spotify
+  else
+    fancy_echo "Spotify detected"
+    fancy_echo "Skipping Spotify..."
+  fi
 
-if [ ! -d /Applications/'Figma.app' ]; then
-  fancy_echo "Figma not found.. installing Figma"
-  brew install --cask figma
-else
-  fancy_echo "Figma detected"
-  fancy_echo "Skipping Figma..."
-fi
+  if [ ! -d /Applications/'Figma.app' ]; then
+    fancy_echo "Figma not found.. installing Figma"
+    brew install --cask figma
+  else
+    fancy_echo "Figma detected"
+    fancy_echo "Skipping Figma..."
+  fi
 
-if [ ! -d /Applications/'Alfred 4.app' ]; then
-  fancy_echo "Alfred not found.. installing Alfred"
-  brew install --cask alfred
-else
-  fancy_echo "Alfred detected"
-  fancy_echo "Skipping Alfred..."
+  if [ ! -d /Applications/'Alfred 4.app' ]; then
+    fancy_echo "Alfred not found.. installing Alfred"
+    brew install --cask alfred
+  else
+    fancy_echo "Alfred detected"
+    fancy_echo "Skipping Alfred..."
+  fi
 fi
 
 if [ ! -f ./setup_script.sh ]; then

--- a/setup_script.sh
+++ b/setup_script.sh
@@ -38,13 +38,36 @@ fi
 # Why do we install it for everyone?
 #   It's the program that much more of this script relies on
 #
-if [ ! -f /usr/local/bin/brew ]; then
+# set expected Homebrew install dir by processor architecture
+case $(arch) in
+  'arm64')
+    BREW_DIR=/opt/homebrew/bin
+    ;;
+  'x86_64')
+    BREW_DIR=/usr/local/bin
+    ;;
+  *)
+    unset BREW_DIR
+    ;;
+esac
+
+if ! [[ -z "$BREW_DIR" ]] && ! [[ -f $BREW_DIR/brew ]]; then
   fancy_echo "Homebrew not found.. installing Homebrew"
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-else
+  if [[ $BREW_DIR == /opt/homebrew/bin ]]; then
+    echo '# Set PATH, MANPATH, etc., for Homebrew.' >> ~/.zprofile
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+    fancy_echo "brew added to PATH"
+  fi
+  brew -v
+elif ! [[ -z "$BREW_DIR" ]] && [[ $(which brew) == $BREW_DIR/brew ]]; then
   fancy_echo "Homebrew detected"
   fancy_echo "Updating brew"
   brew update
+  brew -v
+else
+  fancy_echo "No action taken for Homebrew; path did not match CPU architecture"
 fi
 
 if [ ! -d /Applications/"Google Chrome.app" ]; then

--- a/setup_script.sh
+++ b/setup_script.sh
@@ -105,13 +105,13 @@ else
     fancy_echo "1password detected"
     fancy_echo "Skipping 1password..."
   fi
-
-  if [ ! -d /Applications/'Spotify.app' ]; then
-    fancy_echo "Spotify not found.. installing Spotify"
-    brew install --cask spotify
-  else
+    
+  if [[ -d /Applications/'Spotify.app' ]] || [[ -d "$HOME/Applications/Chrome Apps.localized/Spotify.app" ]]; then
     fancy_echo "Spotify detected"
     fancy_echo "Skipping Spotify..."
+  else
+    fancy_echo "Spotify not found.. installing Spotify"
+    brew install --cask spotify
   fi
 
   if [ ! -d /Applications/'Figma.app' ]; then


### PR DESCRIPTION
Handles some issues I encountered on a M1 MBP new out of the box upgraded to Ventura 13.1 

- Set the expected path for `brew` based on CPU type returned by `arch`
- Skip dependent app installations when `brew` does not appear in PATH
- Check for alternative Spotify installation as a Chrome progressive web app